### PR TITLE
Fix web search functionality with enhanced error handling and format …

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -10,7 +10,7 @@
   "license": "GPL-v3.0-or-later",
   
   "host_application": {
-    "min_version": "0.10.2"
+    "min_version": "0.11.0"
   },
   "homepage_url": "https://github.com/CharTyr/Maibot_topic_finder_plugin",
   "repository_url": "https://github.com/CharTyr/Maibot_topic_finder_plugin",


### PR DESCRIPTION
  描 述 ：
  ## 问 题 描 述
  修 复 联 网 搜 索 功 能 中 "❌  未 获 取 到 联 网 信 息 ， 请 检 查 配 置 "的 错 误 问 题 。
  ## 修 复 内 容
  ### 🔧 增 强 错 误 处 理 和 日 志
  - 添 加 详 细 的 调 试 日 志 ， 包 括 API请 求 过 程 和 响 应 状 态
  - 增 加 特 定 的 异 常 处 理 （ 连 接 错 误 、 超 时 、 HTTP错 误 ）
  - 提 供 更 清 晰 的 错 误 信 息 定 位
  ### 📄 改 进 API响 应 解 析
  - 支 持 4种 不 同 的 响 应 格 式 ：
    - 结 构 化 格 式 （ 标 题 ： xxx， 描 述 ： xxx）
    - JSON格 式
    - 自 由 文 本 格 式 （ 按 段 落 分 割 ）
    - 列 表 格 式 （ 1. 2. 3. 或  - 开 头 ）
  - 增 加 多 种 标 题 和 描 述 的 识 别 关 键 词
  - 当 所 有 解 析 失 败 时 ， 将 整 个 内 容 作 为 一 条 信 息 保 存
  ### 🌐 网 络 连 接 和 API可 用 性 检 测
  - 新 增  `_check_api_availability()` 方 法 ， 在 获 取 信 息 前 先 测 试 API连 接
  - 支 持 快 速 连 接 测 试 ， 避 免 长 时 间 等 待 无 效 请 求
  - 当 API不 可 用 时 自 动 返 回 缓 存 信 息
  ### 💬 优 化 用 户 反 馈
  - `/web_info_test` 命 令 现 在 提 供 详 细 的 错 误 诊 断 信 息
  - 新 增  `/web_api_test` 命 令 专 门 用 于 测 试 API连 接 状 态
  - 错 误 提 示 包 含 具 体 的 配 置 检 查 建 议
  ## 新 增 功 能
  ### 🆕 测 试 命 令
  - `/web_api_test` - 快 速 测 试 API连 接 状 态
  - `/web_info_test` - 完 整 测 试 联 网 信 息 获 取 功 能 （ 增 强 版 ）
  ## 测 试 建 议
  1. 首 先 运 行  `/web_api_test` 检 查 API连 接 状 态
  2. 如 果 连 接 正 常 ， 使 用  `/web_info_test` 测 试 完 整 功 能
  3. 检 查 配 置 文 件  `config.toml` 中 的  `[web_llm]` 部 分 配 置
  ## 兼 容 性
  - 更 新  manifest 版 本 要 求 至  0.11.0
  - 向 后 兼 容 现 有 配 置 文 件
  - 保 持 原 有 功 能 接 口 不 变
  ## 影 响 范 围
  - ✅  修 复 联 网 搜 索 功 能 错 误
  - ✅  提 升 用 户 体 验 和 错 误 诊 断
  - ✅  增 强 系 统 稳 定 性
  - ✅  无 破 坏 性 更 改