### PR TITLE
Add OpenMixBoard overview documentation

### DIFF
--- a/OpenMixBoard.md
+++ b/OpenMixBoard.md
@@ -1,0 +1,28 @@
+# OpenMixBoard
+
+OpenMixBoard is an open-source toolkit for building collaborative audio experiences. It combines the flexibility of a digital DJ mixing console with real-time sharing features, enabling musicians, hobbyists, and event hosts to co-create playlists, experiment with live looping, and broadcast sessions to their communities.
+
+## Why OpenMixBoard?
+- **Open hardware compatibility**: Works with MIDI controllers, DIY Arduino builds, or purely software-based setups.
+- **Collaborative playlists**: Multiple participants can curate tracks simultaneously, vote on upcoming songs, and hand off control seamlessly.
+- **Live performance ready**: Low-latency audio routing, configurable effects racks, and snapshot-based presets keep performances smooth.
+- **Extensible**: Expose custom modules through Python or JavaScript plugins to automate workflows or integrate external services.
+
+## Core Components
+1. **Mixer Engine** – Provides multi-channel routing, EQ, compression, and send effects.
+2. **Deck Interface** – Visual decks for track manipulation, beat syncing, and cue management.
+3. **Collaboration Hub** – Real-time chat, voting, and shared crate management for remote contributors.
+4. **Automation Layer** – Scriptable triggers for lights, visuals, or hardware controllers.
+
+## Getting Started
+1. Clone the repository and install dependencies.
+2. Connect your preferred audio interface or MIDI controller.
+3. Launch the dashboard to configure decks, audio routing, and collaboration rooms.
+4. Share invite links with collaborators to start co-mixing instantly.
+
+## Roadmap
+- Enhanced session recording with stem separation.
+- WebRTC-based low-latency streaming for remote jam sessions.
+- Mobile companion app for quick cueing and monitoring.
+
+OpenMixBoard welcomes community contributions—whether feature ideas, bug reports, or new plugin modules. Dive in, remix, and share your sound.


### PR DESCRIPTION
## Summary
- add a new OpenMixBoard overview guide outlining features, components, and roadmap
- document collaboration, setup, and contribution guidance for the toolkit

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d90881b8f4832da4eaf07050b0e1fb